### PR TITLE
[front] DatetimePicker: fix bugs and make styleguidist sample.

### DIFF
--- a/frontend/src/components/common/datetime-picker/index.tsx
+++ b/frontend/src/components/common/datetime-picker/index.tsx
@@ -18,25 +18,68 @@ type TDateTimePickerCss = 'container' | 'textField';
 
 export interface IDateTimePickerProps extends WithStyles<TDateTimePickerCss> {
     label?: string;
+    value?: Date;
+    onChange: (value?: Date) => void;
 }
 
-const DateTimePicker = (p: IDateTimePickerProps) => {
-    const { classes } = p;
-    return (
-        <form className={classes.container} noValidate>
-            <TextField
-                label={p.label}
-                type="datetime-local"
-                className={classes.textField}
-                InputLabelProps={{
-                    shrink: true,
-                }}
-                inputProps={{
-                    className: 'date-time-picker__input'
-                }}
-            />
-        </form>
-    );
+const inputLabelProps = {
+    shrink: true,
 };
+
+const inputProps = {
+    className: 'date-time-picker__input'
+};
+
+function isValidDate(d: any) {
+    return d instanceof Date && !isNaN(d as any);
+}
+
+class DateTimePicker extends React.Component<IDateTimePickerProps, never> {
+
+    constructor(props: IDateTimePickerProps) {
+        super(props);
+    }
+
+    private handleBlur = () => {
+        if (this.props.onChange !== undefined) {
+            const value = this.inputRef === undefined ? undefined : new Date(this.inputRef.value);
+            console.log('inputRef value [' + value + ']');
+            this.props.onChange(value);
+        }
+    }
+
+    private inputRef: any;
+
+    private saveInputRef = (ref: any) => {
+        this.inputRef = ref;
+    }
+
+    private dateAsString = () => {
+        const date = this.props.value;
+        return date === undefined || !isValidDate(date)
+            ? ''
+            : date.toISOString().substring(0, 16);
+    }
+
+    public render() {
+        console.log(this.dateAsString());
+        const { classes, label, value, onChange, ...p } = this.props;
+        return (
+            <form className={classes.container} noValidate>
+                <TextField
+                    inputRef={this.saveInputRef}
+                    label={label}
+                    type="datetime-local"
+                    className={classes.textField}
+                    InputLabelProps={inputLabelProps}
+                    inputProps={inputProps}
+                    onBlur={this.handleBlur}
+                    defaultValue={this.dateAsString()}
+                    {...p}
+                />
+            </form>
+        );
+    }
+}
 
 export default withStyles(styles)(DateTimePicker);

--- a/frontend/src/components/common/datetime-picker/readme.md
+++ b/frontend/src/components/common/datetime-picker/readme.md
@@ -1,2 +1,29 @@
+```js
+class Container extends React.Component {
+    constructor() {
+        this.state = { value: new Date() };
+    }
+    
+    handleChangeDate (value) {
+        this.setState({ value });
+    }
 
-    <DateTimePicker label="Date" />
+    render() {
+        return (
+            <div>
+                <DatetimePicker
+                    label="Date"
+                    value={this.state.value}
+                    onChange={(v) => this.handleChangeDate(v)}
+                />
+                Selected date: {this.state.value.toLocaleString()}
+            </div>
+        );
+    }
+}
+
+<Container />
+```
+
+
+    


### PR DESCRIPTION
This component isn't seems good enough. I.e. component input must receive full valid date with time, only after that it updates its value. Thus unable to specify date only (without time part).