### PR TITLE
[backend] refactor: make config great again

### DIFF
--- a/backend/cmd/filler/main.go
+++ b/backend/cmd/filler/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	cmd.NewCmd(run).Execute()
+	_ = cmd.NewCmd(run).Execute()
 }
 
 func run(app cmd.AppContext) error {

--- a/backend/etc/filler.yaml
+++ b/backend/etc/filler.yaml
@@ -8,9 +8,11 @@ database:
   password: postgres
   database: app
 
-migrator:
-  directory: ./migrations
-  dialect: postgres
-
 filler:
-  endpoint: "https://sidechain.livenet.sonm.com"
+  concurrency: 50
+
+geth:
+  # local node (fast)
+  endpoint: "http://127.0.0.1:8545"
+  # or remove one (slow)
+  # endpoint: "https://sidechain.livenet.sonm.com"

--- a/backend/filler/config.go
+++ b/backend/filler/config.go
@@ -1,25 +1,47 @@
 package filler
 
 import (
+	"fmt"
 	"github.com/jinzhu/configor"
 	"github.com/sonm-io/explorer/backend/storage"
 )
 
 type fillerConfig struct {
+	Concurrency uint `yaml:"concurrency" required:"true" default:"50"`
+}
+
+type gethConfig struct {
 	Endpoint string `yaml:"endpoint" required:"true"`
 }
 
 type Config struct {
-	Filler   *fillerConfig   `yaml:"filler" required:"true"`
-	Database *storage.Config `yaml:"database" required:"true"`
+	Filler   fillerConfig   `yaml:"filler" required:"true"`
+	Geth     gethConfig     `yaml:"geth" required:"true"`
+	Database storage.Config `yaml:"database" required:"true"`
+}
+
+func (c *Config) validate() error {
+	if c.Filler.Concurrency == 0 {
+		return fmt.Errorf("cannot use zero concurrency")
+	}
+
+	if c.Filler.Concurrency >= 500 {
+		return fmt.Errorf("it's too danger to use so many threads")
+	}
+
+	return nil
 }
 
 func NewConfig(path string) (*Config, error) {
 	cfg := &Config{}
 
-	err := configor.Load(cfg, path)
-	if err != nil {
+	if err := configor.Load(cfg, path); err != nil {
 		return nil, err
 	}
+
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	return cfg, nil
 }


### PR DESCRIPTION
inside:
- split geth and filler configs;
- concurrency factor is now configurabe;
- better naming, some docstrings;


@sokel PTAL